### PR TITLE
Configurable border radius

### DIFF
--- a/components/Overlay.jsx
+++ b/components/Overlay.jsx
@@ -25,6 +25,9 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
       get radius () {
         return get('lensRadius', 100);
       },
+      get borderRadius () {
+        return get('borderRadius', 50);
+      },
       get zooming () {
         return get('zoomRatio', 2);
       },
@@ -33,6 +36,9 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
       },
       set radius (v) {
         return set('lensRadius', v);
+      },
+      set borderRadius (v) {
+        return set('borderRadius', v);
       },
       set zooming (v) {
         return set('zoomRatio', v);
@@ -44,6 +50,7 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
     this.lensConfig = {
       show: false,
       radius: this.settings.radius,
+      borderRadius: this.settings.borderRadius,
       zooming: this.settings.zooming,
       wheelStep: this.settings.wheelStep,
       positionX: 0,

--- a/components/Overlay.jsx
+++ b/components/Overlay.jsx
@@ -25,9 +25,6 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
       get radius () {
         return get('lensRadius', 100);
       },
-      get borderRadius () {
-        return get('borderRadius', 50);
-      },
       get zooming () {
         return get('zoomRatio', 2);
       },
@@ -36,9 +33,6 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
       },
       set radius (v) {
         return set('lensRadius', v);
-      },
-      set borderRadius (v) {
-        return set('borderRadius', v);
       },
       set zooming (v) {
         return set('zoomRatio', v);
@@ -50,7 +44,6 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
     this.lensConfig = {
       show: false,
       radius: this.settings.radius,
-      borderRadius: this.settings.borderRadius,
       zooming: this.settings.zooming,
       wheelStep: this.settings.wheelStep,
       positionX: 0,
@@ -61,7 +54,10 @@ module.exports = class ImageToolsOverlay extends React.PureComponent {
         borderColor: int2hex(this.props.settings.get('lensColor', 0)),
         get imageRendering () {
           return get('disableAntiAliasing', null) ? 'pixelated' : null;
-        }
+        },
+        get borderRadius () {
+          return `${get('borderRadius', 50)}%`;
+        },
       }
     };
     this.Patcher = new Patcher.Overlay(props.settings, props.children, {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -18,6 +18,7 @@
   "IMAGE_TOOLS_ZOOM_RATIO": "Zoom ratio",
   "IMAGE_TOOLS_ZOOM_RATIO_NOTE": "Magnifying the image in the lens",
   "IMAGE_TOOLS_LENS_RADIUS": "Lens radius",
+  "IMAGE_TOOLS_LENS_BORDER_RADIUS": "Lens border radius",
   "IMAGE_TOOLS_REVERSE_SEARCH_IMAGES_SERVICES": "Reverse search images services",
   "IMAGE_TOOLS_DISABLE_LENS": "Disable lens",
   "IMAGE_TOOLS_IMAGE_COPIED": "Image copied",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -18,6 +18,7 @@
   "IMAGE_TOOLS_ZOOM_RATIO": "Коэффициент зума",
   "IMAGE_TOOLS_ZOOM_RATIO_NOTE": "Увеличение изображения в линзе",
   "IMAGE_TOOLS_LENS_RADIUS": "Радиус линзы",
+  "IMAGE_TOOLS_LENS_BORDER_RADIUS": "Радиус скругления линзы",
   "IMAGE_TOOLS_REVERSE_SEARCH_IMAGES_SERVICES": "Сервисы поиска изображений",
   "IMAGE_TOOLS_DISABLE_LENS": "Отключить линзу",
   "IMAGE_TOOLS_IMAGE_COPIED": "Изображение скопировано",

--- a/structures/lensSettings.js
+++ b/structures/lensSettings.js
@@ -35,6 +35,15 @@ module.exports = function ({ get, set }) {
     },
     {
       type: 'slider',
+      get name () { return Messages.IMAGE_TOOLS_LENS_BORDER_RADIUS; },
+      value: Number(get('borderRadius', 50)).toFixed(),
+      minValue: 0,
+      maxValue: 50,
+      onChange: (v) => set('borderRadius', v),
+      renderValue: (v) => `${(v * 2).toFixed(1)}%`
+    },
+    {
+      type: 'slider',
       get name () { return Messages.IMAGE_TOOLS_SCROLL_STEP; },
       value: Number(get('wheelStep', 1)).toFixed(2),
       minValue: 0.1,

--- a/style.scss
+++ b/style.scss
@@ -7,7 +7,6 @@
 }
 .image-tools-lens {
     border: 2px solid var(--interactive-hover);
-    border-radius: 50%;
     margin: -2px;
     display: none;
     overflow: hidden;

--- a/tools/Lens/Index.jsx
+++ b/tools/Lens/Index.jsx
@@ -17,7 +17,6 @@ module.exports = class Lens extends React.PureComponent {
         top: `${parentPos.y}px`,
         width: `${parentSize.w}px`,
         height: `${parentSize.h}px`,
-        borderRadius: `${this.props.borderRadius}%`,
         ...this.props.style
       };
       style.child = {

--- a/tools/Lens/Index.jsx
+++ b/tools/Lens/Index.jsx
@@ -17,6 +17,7 @@ module.exports = class Lens extends React.PureComponent {
         top: `${parentPos.y}px`,
         width: `${parentSize.w}px`,
         height: `${parentSize.h}px`,
+        borderRadius: `${this.props.borderRadius}%`,
         ...this.props.style
       };
       style.child = {


### PR DESCRIPTION
Lets the user change the border radius. I took inspiration from the toggle-able round lens feature of the [BetterDiscord equivalent](https://github.com/1Lighty/BetterDiscordPlugins/tree/master/Plugins/BetterImageViewer) of this plugin.

I don't know any Russian so I translated the setting via [DeepL](https://deepl.com/translate), if there's anything wrong with the translation feel free to comment!

I'd like to work on this a bit more before it's merged, but it can be merged at any time.

**Default Radius:**
![](https://media.discordapp.net/attachments/365455566329348097/839566208780075019/2021-05-05_14.15.51.png)

**50% Radius:**
![](https://media.discordapp.net/attachments/365455566329348097/839566209292435527/2021-05-05_14.16.09.png)

**0% Radius:**
![](https://media.discordapp.net/attachments/365455566329348097/839566208991100948/2021-05-05_14.16.00.png)